### PR TITLE
ability to create more noticeably distinct notes

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-This is version 1.2.1
+This is version HEAD
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as file:
     long_description = file.read()
 
 setup(name='MIDIUtil',
-      version='1.2.1',
+      version='HEAD',
       description='A pure python library for creating multi-track MIDI files',
       author='Mark Conway Wirt',
       author_email='MarkCWirt@gmail.com',


### PR DESCRIPTION
Hey I had an idea but don't know if it could be coded into the already existent code but here goes.

I think it would be cool if when writing the midi file in a series of degrees
that there was a line of code that would set the length of each specific note to a desired uniform duration say,
3/16ths of a measure and quantize the beginning of each slice to start on some beat-- say,
to the nearest quarter note-- so that there exists a brief period of silence between each note

The reason being is that this would allow for more notable distinct notes so that when using something like
sonic visualiser it would be able to correctly read which notes were used to compile the audio.

More specifically what I am suggesting is the ability to control the four stages of musical envelope
This being: attack, decay, sustain, and release (ADSR)

Attack is the time taken for initial run-up of level from nil to peak, beginning when the key is pressed.
Decay is the time taken for the subsequent run down from the attack level to the designated sustain level.
Sustain is the level during the main sequence of the sound's duration, until the key is released.
Release is the time taken for the level to decay from the sustain level to zero after the key is released.
While attack, decay, and release refer to time, sustain refers to level.
https://en.wikipedia.org/wiki/Envelope_(music)

The reason for this request is that I am currently working on a project to turn written text into music
and then turn that music back into text.

And as midi allows for a degree range of 0-127 I have found your script to be very suitable. also
sonic visualiser is able to pick out the exact notes used in your script meaning that when I write a file (50,40,60)
I can extract these same numbers in sonic visualiser using the polyphonic Transcription [university of alcante] Transform

However due to the various length of notes played (depending on pitch) and lack of a gap between notes.
it is not always possible to pick out the exact notes and I believe that setting a fixed duration for each note
with a fixed period of silence would make the notes more noticeable and thus allow sonic visualiser to pick out
all the degrees that went into creating the file and allow for a successful decryption 